### PR TITLE
#1788: Corrected language IDs, added missing translations

### DIFF
--- a/xsd/otds-schema-common.xsd
+++ b/xsd/otds-schema-common.xsd
@@ -6754,7 +6754,7 @@ Reference to a combined component. Reference to prices for a CombiComponent is e
 				<xs:sequence>
 					<xs:element name="GenericTag" type="GenericTagType" minOccurs="0" maxOccurs="unbounded" internal:otdsversion="1.9">
 						<xs:annotation>
-							<xs:documentation xml:lang="de">GenericTags sind Markierungen, deren Value von einer Funktion abhängt.
+							<xs:documentation xml:lang="de" xml:id="de_400">GenericTags sind Markierungen, deren Value von einer Funktion abhängt.
 								Folgende Funktionen sind aktuell integriert: - SortedCandidateGroup
 								Die SortedCandidateGroup definiert eine Gruppierung von
 								Angebots-Kandidaten, die in eine bestimmte Reihenfolge gebracht
@@ -6766,7 +6766,7 @@ Reference to a combined component. Reference to prices for a CombiComponent is e
 								Bedingungen an die GenericTags formuliert werden. Die Funktion
 								"SortedCandidateGroup findet keine Berücksichtigung in der
 								Preisberechnung. </xs:documentation>
-							<xs:documentation xml:lang="en">Generic Tags are labels whose value depends on a function.
+							<xs:documentation xml:lang="en" xml:id="en_400">Generic Tags are labels whose value depends on a function.
 								The following functions are currently integrated: -
 								SortedCandidateGroup The SortedCandidateGroup defines a group of
 								offer candidates to be placed in a certain order. Each offer will
@@ -6795,13 +6795,13 @@ Reference to a combined component. Reference to prices for a CombiComponent is e
 				Wert übereinstimmen müssen, damit die Bedingung erfüllt ist. Die Felder können
 				sowohl Tags mit Class sein, als auch Elemente. Bei Tags definiert dieses Element die
 				Tag Position und die Class die entsprechende Class des Tags.</xs:documentation>
-			<xs:documentation xml:lang="de" xml:id="en_404">Match serves to define fields that must match in value so that the condition is satisfied. The fields can be both tags with class, as well as elements. For tags the element defines the tag position and the class the corresponding class of the tag.</xs:documentation>
+			<xs:documentation xml:lang="en" xml:id="en_404">Match serves to define fields that must match in value so that the condition is satisfied. The fields can be both tags with class, as well as elements. For tags the element defines the tag position and the class the corresponding class of the tag.</xs:documentation>
 		</xs:annotation>
 		<xs:choice minOccurs="2" maxOccurs="unbounded">
 			<xs:element name="Key" type="EmptyKeyConditionType" internal:otdsversion="1.9">
 				<xs:annotation>
 					<xs:documentation xml:lang="de" xml:id="de_3">Dieses Element adressiert einen bestimmten Key innerhalb des Angebotskontextes. Der Angebotskontext besteht dabei aus allen möglichen Kombinationen der in der ProductRule angegebenen Komponenten. Die Kombinatorik geht dabei bis auf die Terminebene hinunter.</xs:documentation>
-					<xs:documentation xml:lang="de" xml:id="en_3">This element addresses a specific key within the
+					<xs:documentation xml:lang="en" xml:id="en_3">This element addresses a specific key within the
 						offer context. The offer context consists of all possible combinations of
 						the components specified in the ProductRule. The combinatorics go down to
 						the date level.</xs:documentation>
@@ -6810,7 +6810,7 @@ Reference to a combined component. Reference to prices for a CombiComponent is e
 			<xs:element name="Tag" type="EmptyTagConditionType">
 				<xs:annotation>
 					<xs:documentation xml:lang="de" xml:id="de_405">Dieses Element adressiert ein bestimmtes Tag innerhalb des Angebotskontextes. Der Angebotskontext besteht dabei aus allen möglichen Kombinationen der in der ProductRule angegebenen Komponenten. Die Kombinatorik geht dabei bis auf die Terminebene hinunter.</xs:documentation>
-					<xs:documentation xml:lang="de" xml:id="en_405">This element addresses a specific tag within
+					<xs:documentation xml:lang="en" xml:id="en_405">This element addresses a specific tag within
 						the offer context. The offer context consists of all possible combinations
 						of the components specified in the ProductRule. The combinatorics go down to
 						the date level.</xs:documentation>
@@ -6821,7 +6821,7 @@ Reference to a combined component. Reference to prices for a CombiComponent is e
 					<xs:documentation xml:lang="de" xml:id="de_535">Dieses Element adressiert ein bestimmtes ConditionalTag innerhalb des Angebotskontextes. 
 Bei der Auswertung, reicht es wenn das ConditionalTag in einem Day- oder PersonKnoten identisch ist.
 Der Angebotskontext besteht dabei aus allen möglichen Kombinationen der in der ProductRule angegebenen Komponenten. Die Kombinatorik geht dabei bis auf die Terminebene hinunter.</xs:documentation>
-					<xs:documentation xml:lang="de" xml:id="en_535">This element addresses a specific tag within
+					<xs:documentation xml:lang="en" xml:id="en_535">This element addresses a specific tag within
 						the offer context. The offer context consists of all possible combinations
 						of the components specified in the ProductRule. The combinatorics go down to
 						the date level.</xs:documentation>
@@ -6837,7 +6837,7 @@ Der Angebotskontext besteht dabei aus allen möglichen Kombinationen der in der 
 						Über das Attribut "Source" wird die Unterkomponente adressiert.
 						Der Body dieses Elements spezifiziert den SourceKnoten als nächsten
 						untergeordneten Knoten unterhalb der adressierten Unterkomponente.</xs:documentation>
-					<xs:documentation xml:lang="de" xml:id="en_406">This element addresses a specific node or parameter within
+					<xs:documentation xml:lang="en" xml:id="en_406">This element addresses a specific node or parameter within
 						the offer context. The offer context consists of all possible combinations
 						of the components specified in the ProductRule. The combinatorics go down to
 						the date level.
@@ -7891,7 +7891,7 @@ It is possible to provide a list of values separated by spaces. The list defines
 						<xs:element name="ProductPrice" type="ProductPriceConditionType" internal:otdsversion="1.9"/>
 						<xs:element name="GroupedPerson" type="EmptyElementType">
 							<xs:annotation>
-								<xs:documentation xml:lang="de">Dieses Element wird nur für GenericAbsolutes benutzt und hat
+								<xs:documentation xml:lang="de" xml:id="de_5864">Dieses Element wird nur für GenericAbsolutes benutzt und hat
 									in anderem Kontext keine Auswirkung. Das Element hängt direkt
 									zusammen mit dem Element GroupAbsolutePriceItemsBy/Person und
 									definiert, dass die GenericValues separat auf die Kostenknoten
@@ -7899,7 +7899,7 @@ It is possible to provide a list of values separated by spaces. The list defines
 									Element Person innerhalb von GroupAbsolutePriceItemsBy nicht
 									gesetzt, so hat GroupedPerson keine
 									Auswirkung.</xs:documentation>
-								<xs:documentation xml:lang="en">This element is used only for GenericAbsolutes and has no
+								<xs:documentation xml:lang="en" xml:id="en_5864">This element is used only for GenericAbsolutes and has no
 									effect in a different context. The element is directly related
 									to the element GroupAbsolutePriceItemsBy / person and defined
 									that the Generic Values are divided on the cost-nodes of the
@@ -8052,14 +8052,14 @@ Die Bedingung ist erfüllt, wenn einer der
 						<xs:element name="ProductPrice" type="ProductPriceConditionType"/>
 						<xs:element name="GroupedDay" type="EmptyElementType">
 							<xs:annotation>
-								<xs:documentation xml:lang="de">Dieses Element wird nur für GenericAbsolutes benutzt und hat in anderem
+								<xs:documentation xml:lang="de" xml:id="de_5865">Dieses Element wird nur für GenericAbsolutes benutzt und hat in anderem
 									Kontext keine Auswirkung. Das Element hängt direkt zusammen mit
 									dem Element GroupAbsolutePriceItemsBy/Day und definiert, dass
 									die GenericValues separat auf die Kostenknoten der separat
 									betrachteten Tage aufgeteilt werden. Ist das Element Day
 									innerhalb von GroupAbsolutePriceItemsBy nicht gesetzt, so hat
 									GroupedDay keine Auswirkung.</xs:documentation>
-								<xs:documentation xml:lang="en">This element is used only for GenericAbsolutes and has no
+								<xs:documentation xml:lang="en" xml:id="en_5865">This element is used only for GenericAbsolutes and has no
 									effect in a different context. The element is directly related
 									to the element GroupAbsolutePriceItemsBy / day and defines that
 									the Generic Values are divided on the cost-nodes of the
@@ -8141,7 +8141,7 @@ Prices that have a DayImpactCondition attached to them are only valid for certai
 						</xs:element>
 						<xs:element name="GroupedAbsolute" type="EmptyElementType">
 							<xs:annotation>
-								<xs:documentation xml:lang="de">Dieses Element wird nur für GenericAbsolutes benutzt und hat in anderem
+								<xs:documentation xml:lang="de" xml:id="de_5866">Dieses Element wird nur für GenericAbsolutes benutzt und hat in anderem
 									Kontext keine Auswirkung. Das Element hängt direkt zusammen mit
 									dem Element GroupAbsolutePriceItemsBy/AbsolutePriceItem und
 									definiert, dass die GenericValues separat auf die Kostenknoten
@@ -8149,7 +8149,7 @@ Prices that have a DayImpactCondition attached to them are only valid for certai
 									das Element AbsolutePriceItem innerhalb von
 									GroupAbsolutePriceItemsBy nicht gesetzt, so hat GroupedAbsolute
 									keine Auswirkung.</xs:documentation>
-								<xs:documentation xml:lang="en">This element is used only for GenericAbsolutes and has no
+								<xs:documentation xml:lang="en" xml:id="de_5866">This element is used only for GenericAbsolutes and has no
 									effect in a different context. The element is directly related
 									to the element GroupAbsolutePriceItemsBy/AbsolutePriceItem and
 									defines that the Generic Values are divided on the cost-nodes of
@@ -8239,13 +8239,16 @@ Nodes are to be addressed using the "Source" attribute, and for tags also via "L
 			</xs:element>
 			<xs:element name="NonImpact" internal:otdsversion="1.9">
 				<xs:annotation>
-					<xs:documentation>Mit dem NonImpact Wrapper kann man ausdrücken, dass einen komplexe Bedingung, die auch ImpactBedingungen enthält am Ende doch als NICHT-Impact ausgewertet wird. 
-Zum Beispiel die Bedingung ein Preis gilt, wenn ein Freitag mit einer Saison A enthalten ist. Das ist erreichbar, indem man 2 ImpactBedingungen verundet und diese dann mit dem NonImpact-Wrapper umschließt.
+					<xs:documentation xml:lang="de" xml:id="de_5867">Mit dem NonImpact Wrapper kann man ausdrücken, dass eine komplexe Bedingung, die auch ImpactBedingungen enthält am Ende doch als NICHT-Impact ausgewertet wird. 
+Zum Beispiel die Bedingung, dass ein Preis gilt, wenn ein Freitag mit einer Saison A enthalten ist. Das ist erreichbar, indem man zwei ImpactBedingungen verundet und diese dann mit dem NonImpact-Wrapper umschließt.
 Der NonIMpact-Wrapper kann auch dabei helfen, wenn man kombinierte CheckIn- und StaySeasons mt nur einem ConditionalTag ausdrücken will.
 Dabei kann mit den Elementen DayBase und PersonBase definiert werden, welche Kostenknoten überhaupt bei der Auswertung berücksichtigt werden.
-Das Attribut "EvaluationMode" definiert ob ein Kostenknoten die Bedingung erfüllen muss oder ob es alle erfüllen müssen.
-
-</xs:documentation>
+Das Attribut "EvaluationMode" definiert ob ein Kostenknoten die Bedingung erfüllen muss oder ob es alle erfüllen müssen.</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5867">The NonImpact Wrapper allows to express that a complex condition, which might also contain ImpactConditions after all will be interpreted as a NON-Impact. 
+						For example: a price is valid, if a Friday with a Season A is included. This can be realised by connecting two ImpactConditions with AND and enclosing those with the NonImpact-Wrapper.
+						Der NonIMpact-Wrapper kann auch dabei helfen, wenn man kombinierte CheckIn- und StaySeasons mt nur einem ConditionalTag ausdrücken will.
+						Here the elements DayBase and PersonBase allow to define, which cost nodes need to be considered in the interpretation.
+						The attribute "EvaluationMode" defines if a cost node has to fulfill the condition or if all have to fulfill it.</xs:documentation>
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
@@ -8254,7 +8257,8 @@ Das Attribut "EvaluationMode" definiert ob ein Kostenknoten die Bedingung erfül
 					</xs:sequence>
 					<xs:attribute name="EvaluationMode" type="EvaluationModeEnum" default="Any">
 						<xs:annotation>
-							<xs:documentation>Mit diesem Attribut definiert man, ob die NonImpact Bedingung erfüllt ist wenn ein beliebiger ("Any") Kostenknoten die condition erfüllt oder wenn alle ("All") durch DayBase und PersonBase  definierten Kostenknoten die Condition erfüllen.</xs:documentation>
+							<xs:documentation xml:lang="de" xml:id="de_5868">Mit diesem Attribut definiert man, ob die NonImpact Bedingung erfüllt ist, wenn ein beliebiger ("Any") Kostenknoten die Condition erfüllt oder wenn alle ("All") durch DayBase und PersonBase definierten Kostenknoten die Condition erfüllen.</xs:documentation>
+							<xs:documentation xml:lang="en" xml:id="en_5868">This attribute helps to define, if a NonImpact Condition is fulfilled when a random ("Any") cost node fulfills the condition or when all ("All") cost nodes which are defined by DayBase and PersonBase fulfill the Condition.</xs:documentation>
 						</xs:annotation>
 					</xs:attribute>
 				</xs:complexType>
@@ -8496,12 +8500,12 @@ Das Attribut "EvaluationMode" definiert ob ein Kostenknoten die Bedingung erfül
 		<xs:sequence>
 			<xs:element name="GenericTag" internal:otdsversion="1.9">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Die GenericTag-Condition definiert eine Bedingung an das GenericTag. Das
+					<xs:documentation xml:lang="de" xml:id="de_5869">Die GenericTag-Condition definiert eine Bedingung an das GenericTag. Das
 						Attribut "Class" referenziert welches GenericTag geprüft wird. Die Bedingung
 						ist erfüllt, wenn der Value des referenzierten GenericTags innerhalb der
 						Value-Bedingungen liegt. Eine GenericTag Bedingung ohne Value ist
 						"False".</xs:documentation>
-					<xs:documentation xml:lang="en">The GenericTag-Condition defines a condition for the
+					<xs:documentation xml:lang="en" xml:id="en_5869">The GenericTag-Condition defines a condition for the
 						GenericTag. The attribute "Class" references, which GenericTag is to be
 						evaluated. The condition is satisfied, if the value of the referenced
 						GenericTag lies within the Value-conditions. A GenericTag condition withour
@@ -8581,8 +8585,8 @@ Das Attribut "EvaluationMode" definiert ob ein Kostenknoten die Bedingung erfül
 		<xs:sequence>
 			<xs:element name="CarRentalStationType" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Art der Mietwagenstation</xs:documentation>
-					<xs:documentation xml:lang="de">Type of car rental station</xs:documentation>
+					<xs:documentation xml:lang="de" xml:id="de_5870">Art der Mietwagenstation</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5870">Type of car rental station</xs:documentation>
 				</xs:annotation>
 				<xs:simpleType>
 					<xs:list itemType="CarRentalStationTypeEnum"/>
@@ -8590,9 +8594,9 @@ Das Attribut "EvaluationMode" definiert ob ein Kostenknoten die Bedingung erfül
 			</xs:element>
 			<xs:element name="CarRentalProductOptions" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Zusätzliche Optionen, die zu einem Mietwagen hinzugebucht werden können oder
+					<xs:documentation xml:lang="de" xml:id="de_5871">Zusätzliche Optionen, die zu einem Mietwagen hinzugebucht werden können oder
 						bereits enthalten sind.</xs:documentation>
-					<xs:documentation xml:lang="en">Additional services that can be added to a rental car booking or that are already included.</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5871">Additional services that can be added to a rental car booking or that are already included.</xs:documentation>
 				</xs:annotation>
 				<xs:simpleType>
 					<xs:list itemType="CarRentalProductOptionsEnum"/>
@@ -8600,8 +8604,8 @@ Das Attribut "EvaluationMode" definiert ob ein Kostenknoten die Bedingung erfül
 			</xs:element>
 			<xs:element name="CarFacilities" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Ausstattungsmerkmale</xs:documentation>
-					<xs:documentation xml:lang="en">Rental car features</xs:documentation>
+					<xs:documentation xml:lang="de" xml:id="de_5872">Ausstattungsmerkmale</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5872">Rental car features</xs:documentation>
 				</xs:annotation>
 				<xs:simpleType>
 					<xs:list itemType="CarRentalFacilityEnum"/>
@@ -8609,16 +8613,15 @@ Das Attribut "EvaluationMode" definiert ob ein Kostenknoten die Bedingung erfül
 			</xs:element>
 			<xs:element name="CarInsurance" type="CarRentalInsuranceType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Das Element Insurance kann mehrfach geliefert werden und beinhaltet die Art
-						der Versicherung, eine Beschreibung, die Deckungssumme und die
-						Selbstbeteiligung.</xs:documentation>
-					<xs:documentation xml:lang="en">The item Insurance can be supplied multiple times and includes the type of insurance, a description, the coverage, and the deductible.</xs:documentation>
+					<xs:documentation xml:lang="de" xml:id="de_5873">Das Element Insurance kann mehrfach geliefert werden und beinhaltet die Art
+						der Versicherung, eine Beschreibung, die Deckungssumme und die Selbstbeteiligung.</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5873">The item Insurance can be supplied multiple times and includes the type of insurance, a description, the coverage, and the deductible.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="CarCapacity" type="CarCapacityType" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Angaben zum Fassungsvermögen des Mietwagens. Dieses Fassungsvermögen ersetzt nicht die Occupancy. Das Fassungsvermögen liefert nur Informationen über die maximale empfohlene Anzahl von Personen und Gepäck.</xs:documentation>
-					<xs:documentation xml:lang="en">Information on the capacity of the rental car. This capacity does not replace the occupancy. The capacity provides information only about the maximum recommended number of passengers and luggage.</xs:documentation>
+					<xs:documentation xml:lang="de" xml:id="de_5874">Angaben zum Fassungsvermögen des Mietwagens. Dieses Fassungsvermögen ersetzt nicht die Occupancy. Das Fassungsvermögen liefert nur Informationen über die maximale empfohlene Anzahl von Personen und Gepäck.</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5874">Information on the capacity of the rental car. This capacity does not replace the occupancy. The capacity provides information only about the maximum recommended number of passengers and luggage.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -8627,26 +8630,26 @@ Das Attribut "EvaluationMode" definiert ob ein Kostenknoten die Bedingung erfül
 		<xs:sequence>
 			<xs:element name="Insurance" type="CarRentalInsuranceEnum">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Versicherungsart</xs:documentation>
-					<xs:documentation xml:lang="en">Type of insurance</xs:documentation>
+					<xs:documentation xml:lang="de" xml:id="de_5875">Versicherungsart</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5875">Type of insurance</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Description" type="xs:string" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Beschreibung der Versicherung</xs:documentation>
-					<xs:documentation xml:lang="en">Description of insurance</xs:documentation>
+					<xs:documentation xml:lang="de" xml:id="de_5876">Beschreibung der Versicherung</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5876">Description of insurance</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="AmountOfCover" type="xs:decimal" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Die Schadenssumme, welche durch die Versicherung abgedeckt wird</xs:documentation>
-					<xs:documentation xml:lang="en">The damage sum which is covered by the insurance</xs:documentation>
+					<xs:documentation xml:lang="de" xml:id="de_5877">Die Schadenssumme, welche durch die Versicherung abgedeckt wird</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5877">The damage sum which is covered by the insurance</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Excess" type="xs:decimal" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Höhe der Selbstbeteiligung im Falle eines Schadens</xs:documentation>
-					<xs:documentation xml:lang="en">Amount of the deductible in case of damage</xs:documentation>
+					<xs:documentation xml:lang="de" xml:id="de_5878">Höhe der Selbstbeteiligung im Falle eines Schadens</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5878">Amount of the deductible in case of damage</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -8655,14 +8658,14 @@ Das Attribut "EvaluationMode" definiert ob ein Kostenknoten die Bedingung erfül
 		<xs:sequence>
 			<xs:element name="Passengers" type="xs:positiveInteger" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Maximale Anzahl an Personen</xs:documentation>
-					<xs:documentation xml:lang="en">Max. number of passengers</xs:documentation>
+					<xs:documentation xml:lang="de" xml:id="de_5879">Maximale Anzahl an Personen</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5879">Max. number of passengers</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Bags" type="xs:unsignedInt" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Maximale Anzahl an Gepäckstücken</xs:documentation>
-					<xs:documentation xml:lang="en">Max. number of baggage</xs:documentation>
+					<xs:documentation xml:lang="de" xml:id="de_5880">Maximale Anzahl an Gepäckstücken</xs:documentation>
+					<xs:documentation xml:lang="en" xml:id="en_5880">Max. number of baggage</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>


### PR DESCRIPTION
Wrong language ID: en_3, 404-406, 535. Missing translations: mainly for
CarRental