### PR TITLE
# 1782 Ergänzung zu Komponenten gem. Stephans Kommentar im Ticket

### DIFF
--- a/doku/spec/otds_spezifikation.docbook
+++ b/doku/spec/otds_spezifikation.docbook
@@ -5003,15 +5003,30 @@
 							<code>DefinedComponents/DefineComponent</code> werden kombinierte
 						Komponenten definiert, die aus mehreren Einzelkomponenten bestehen. Im
 						Element <code>Components</code> werden die Komponenten festgelegt, aus denen
-						sich das Produkt zusammensetzt. Jeder Komponente kann dabei durch das
+						sich das Produkt zusammensetzt. Die Komponenten müssen derzeit noch immer vom gleichen
+						Typ, also homogen sein. Es müssen also immer mehrere OnewayFlights oder
+						mehrere Accommodations zusammengefasst sein. Jeder Komponente kann dabei durch das
 						Attribut <code>Name</code> ein frei wählbarer Name gegeben werden, der
 						innerhalb der OTDS-Datenlieferung eindeutig sein muss. Über den Namen kann
 						in <code>Filter</code> und <code>Conditions</code> der eindeutige Bezug zu
 						den einzelnen Komponenten hergestellt werden. Durch die OTDS-weite
 						Eindeutigkeit können auch innerhalb der Komponenten-Stammdaten Bezüge auf
-						diese Namen hergestellt werden, wenn dies notwednig ist. Das optionale
+						diese Namen hergestellt werden, wenn dies notwendig ist. Das optionale
 						Attribut <code>DayAllocationIndex</code> bestimmt die Zuordnung der
-						Komponenten im Reiseverlauf.</para><para xml:id="en_1164" xml:lang="en">Under the element <code>DefinedComponents/DefineComponent</code> combined components can be defined which consist of several individual components. In the element <code>Components</code> the components are determined which make up the product. Using the attribute <code>Name</code> , each component can be given a freely selectable name, which must be unambiguous within the OTDS data delivery. Via the name, it is possible to make an unambiguous reference to individual components in <code>Filter</code> and <code>Conditions</code> . Due to their unambiguity throughout OTDS, it is also possible to make reference to these names within the component master data if required. The optional attribute <code>DayAllocationIndex</code>  defines the allocation of the components in the itinerary.</para>
+						Komponenten im Reiseverlauf. </para><para xml:id="en_1164" xml:lang="en">Under the element
+							<code>DefinedComponents/DefineComponent</code> combined components can
+						be defined which consist of several individual components. In the element
+							<code>Components</code> the components are determined which make up the
+						product. The components at present have to belong to the same type, thus
+						need to be homogeneous. So if grouped, it has to be by OnewayFlights or by
+						Accommodations. Using the attribute <code>Name</code> , each component can
+						be given a freely selectable name, which must be unambiguous within the OTDS
+						data delivery. Via the name, it is possible to make an unambiguous reference
+						to individual components in <code>Filter</code> and <code>Conditions</code>
+						. Due to their unambiguity throughout OTDS, it is also possible to make
+						reference to these names within the component master data if required. The
+						optional attribute <code>DayAllocationIndex</code> defines the allocation of
+						the components in the itinerary.</para>
 					<para xml:id="de_1166" xml:lang="de">Das Element <code>Filter</code> definiert Filterbedingungen, die das Produkt
 						erfüllen muss. Die Filter beziehen sich dabei über das Attribut <code>Source</code>
 						auf die unter <code>Components</code> angegebenen Komponenten.</para><para xml:id="en_1166" xml:lang="en">The element <code>Filter</code>  defines filter conditions which the product must fulfil. The filters thereby refer via the attribute <code>Source</code> to the components specified under <code>Components</code> .</para>


### PR DESCRIPTION
kannst Du bitte noch ergänzen, dass die Componenten derzeit noch immer
vom gleichen Typ also homogen sein müssen.
Es müssen also immer mehrere OnewayFlights oder mehrere Accommodations
sein.