### PR TITLE
Update xsd/otds-schema-common.xsd

### DIFF
--- a/xsd/otds-schema-common.xsd
+++ b/xsd/otds-schema-common.xsd
@@ -1930,18 +1930,18 @@ For the complete list see the technical documentation.</xs:documentation>
 						<xs:documentation xml:lang="de" xml:id="de_9067">Die folgenden Referenzsysteme können aktuell verwendet werden: 
 - Giata (https://www.giata.com/de/multicodes/) 
 - Geonames (http://www.geonames.org/export/codes.html). 
-Eine vollständige Liste finden Sie in der Technischen Dokumentation.</xs:documentation>
+Eine Liste der derzeit bekannten Referenzsysteme finden Sie in der Thematischen Spezifikation.</xs:documentation>
 						<xs:documentation xml:lang="en" xml:id="en_9067">Currently the following reference systems may be used: 
 - Giata (https://www.giata.com/de/multicodes/) 
 - Geonames (http://www.geonames.org/export/codes.html). 
-A complete list may be found in the Technical Documentation.</xs:documentation>
+A list of the currently known reference systems may be found in the Thematical Specification.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="ReferenceType" type="xs:string">
 					<xs:annotation>
-						<xs:documentation xml:lang="de" xml:id="de_9068">In Abhängigkeit vom Referenzsystem wird hiermit der Typ der Referenz festgelegt. Es handelt sich hierbei meist um eine ID zur eindeutigen Identifikation von Hotels, Schiffe etc. oder von Orten, Ortsteilen oder POI etc. Eine vollständige Liste finden Sie in der Technischen Dokumentation.
+						<xs:documentation xml:lang="de" xml:id="de_9068">In Abhängigkeit vom Referenzsystem wird hiermit der Typ der Referenz festgelegt. Es handelt sich hierbei meist um eine ID zur eindeutigen Identifikation von Hotels, Schiffe etc. oder von Orten, Ortsteilen oder POI etc. Eine Liste der derzeit bekannten Referenzsystme finden Sie in der Thematischen Spezifikation.
             </xs:documentation>
-						<xs:documentation xml:lang="en" xml:id="en_9068">In dependency to the reference system the type of the reference is defined here. This will be in most cases an ID for the unambiguous identification of hotels, ships etc. or of cities, districts, or POI etc. A complete list may be found in the Technical Documentation.
+						<xs:documentation xml:lang="en" xml:id="en_9068">In dependency to the reference system the type of the reference is defined here. This will be in most cases an ID for the unambiguous identification of hotels, ships etc. or of cities, districts, or POI etc. A list of the currently known reference systems may be found in the Thematical Specification.
             </xs:documentation>
 					</xs:annotation>
 				</xs:attribute>


### PR DESCRIPTION
Korrektur des Verweises auf die Referenzsysteme: Thematische statt Technische Dokumentation