### PR TITLE
gemäß #1789 (Altlast aus V2.0)

### DIFF
--- a/doku/spec/otds_spezifikation.docbook
+++ b/doku/spec/otds_spezifikation.docbook
@@ -10540,10 +10540,10 @@
 							für die Sortierung (Tags: Numeric)</phrase><phrase xml:id="en_1192"
 							xml:lang="en">Use of Tags as Indices for sorting (Tags:
 							Numeric)</phrase></title>
-					<para xml:id="de_1193" xml:lang="de">Für eine einfache und effektive Möglichkeit
-						Priorisierungsindizes in OTDS zu setzen, wird das Tag-Kozept von OTDS
+					<para xml:id="de_1193" xml:lang="de">Für eine einfache und effektive Möglichkeit,
+						Priorisierungsindizes in OTDS zu setzen, wird das Tag-Konzept von OTDS
 						erweitert. In OTDS V1.0 war es bereits möglich, an verschiedene Knotenpunkte
-						freie Tags also Paare von Zeichenketten zu definieren, um sich später in
+						freie Tags - also Paare von Zeichenketten - zu definieren, um sich später in
 						Bedingungen darauf zu beziehen. </para>
 					<para xml:id="en_1193" xml:lang="en">For a simple and effective way of setting
 						prioritisation indices in OTDS, the Tag concept of OTDS is extended. In OTDS
@@ -10562,14 +10562,17 @@
  ...
 </Otds>]]>				</programlisting>
 
-					<para xml:id="de_1196" xml:lang="de">Die Erweiterung sieht nun vor, dass Tags
-						nicht nur Zeichenketten enthalten können, sondern auch numerische Werte
-						(TagValueType="Numeric") oder numerische Werte (TagValueType="Price"),
-						welche mit Preisen in Interaktion treten können. </para>
-					<para xml:id="en_1196" xml:lang="en">The extension now enables Tags to contain
-						not only character strings, but also numeric values (TagValueType="Numeric")
-						or numeric values (TagValueType="Price"), which can interact with
-						prices.</para>
+					<para xml:id="de_1196" xml:lang="de">Die Erweiterung sieht nun vor, dass Tags nicht nur
+						Zeichenketten enthalten können, sondern auch numerische Werte
+						(TagValueType="Numeric") oder numerische Werte, welche mit Preisen in
+						Interaktion treten können (TagValueType="Price"). Mit Blick auf die
+						Formatierung der numerischen Werte ist zu beachten, dass diese einen "." als
+						Dezimaltrenner und optionale Vorzeichen haben. </para>
+					<para xml:id="en_1196" xml:lang="en">The extension now enables Tags to contain not only
+						character strings, but also numeric values (TagValueType="Numeric") or
+						numeric values, which can interact with prices (TagValueType="Price"). With
+						regard to the formatting of the numeric values, it should be noted that
+						these have a "." as decimal separator and optional signs. </para>
 					<para xml:id="de_1197" xml:lang="de">Beispiel:</para>
 					<para xml:id="en_1197" xml:lang="en">Example:</para>
 					<programlisting language="XML"><![CDATA[<Otds ...>


### PR DESCRIPTION
minimale Rechtschreibkorrektur sowie Umsetzung von #1789: Ergänzung, dass NumericTags eine Dezimalzahl mit "." als Dezimaltrenner und optionalem Vorzeichen ist.