### PR TITLE
Korrektur Wortdreher NeighbourCorrectionComponent

### DIFF
--- a/doku/spec/otds_spezifikation.docbook
+++ b/doku/spec/otds_spezifikation.docbook
@@ -1436,16 +1436,15 @@
 								Nachbarkomponente bzgl. der DayAllocation immer an den CheckOut der
 								vorherigen Komponente an. Falls eine touristische Notwendigkeit
 								erfordert, dass von dieser Regel abgewichen wird, dann kann man dies
-								mit der "NeighbourComponentCorrection" steuern. Mehr Informationen
-								hierzu im Kapitel <link
-									linkend="OtdsStrategyComponentNeigbourComponentCorrection"
+								mit der <code>NeighbourComponentCorrection</code> steuern. Mehr Informationen
+								hierzu im Kapitel <link	linkend="OtdsStrategyComponentNeigbourComponentCorrection"
 									>Definition einer Lücke zwischen benachbarten Komponenten
 									(NeigbourComponentCorrection)</link></para>
 							<para xml:id="en_5863" xml:lang="en">Normally the CheckIn of a neighbouring component with
 								regard to the DayAlloaction always follows the CheckOut of the
 								previous component. If a touristic necessity calls for a deviation
 								from this rule, it can be managed with the help of the
-								"NeighbourComponentCorrection". You may find further information
+								<code>NeighbourComponentCorrection</code>. You may find further information
 								below: <link
 									linkend="OtdsStrategyComponentNeigbourComponentCorrection"
 									>Defining a gap inbetween neighbouring components
@@ -1734,11 +1733,10 @@
 									Flights in Practice</link></para>
 						</section>
 						<section xml:id="OtdsStrategyComponentNeigbourComponentCorrection">
-							<title><phrase xml:id="de_9531" xml:lang="de">Verschiebung von
-									benachbarten Komponenten
-									(NeigbourComponentCorrection)(V2.0)</phrase>
+							<title><phrase xml:id="de_9531" xml:lang="de">Verschiebung von benachbarten Komponenten
+									(NeighbourComponentCorrection)(V2.0)</phrase>
 								<phrase xml:id="en_9531" xml:lang="en">Shift of neighbouring
-									components (NeigbourComponentCorrection)(V2.0)</phrase></title>
+									components (NeighbourComponentCorrection)(V2.0)</phrase></title>
 							<para xml:id="de_9527" xml:lang="de">Normalerweise schließt sich der
 								CheckIn einer Nachbarkomponente bzgl. der DayAllocation immer an den
 								CheckOut der vorherigen Komponente an. Der CheckOut-Termin der
@@ -1836,18 +1834,18 @@
 									</textobject>
 								</mediaobject>
 							</figure>
-							<para xml:id="de_9530" xml:lang="de">Ein zweites gängiges Szenario ist,
-								dass die Kunden bei einer späten Abflugzeit die Möglichkeit haben
-								sollen, ihr Zimmer auch noch am Nachmittag zu nutzen. Beispiele dazu
-								finden Sie im Praxiskapitel unter <link
+							<para xml:id="de_9530" xml:lang="de">Ein zweites gängiges Szenario ist, dass die Kunden bei
+								einer späten Abflugzeit die Möglichkeit haben sollen, ihr Zimmer
+								auch noch am Nachmittag zu nutzen. Beispiele dazu finden Sie im
+								Praxiskapitel unter <link
 									linkend="OtdsExperiencesNeighbourCorrectionComponent"
-									>NeighbourCorrectionComponent</link></para>
-							<para xml:id="en_9530" xml:lang="en">A second common scenario covers the
-								opportunity for customers departing late at night to use their room
-								in the afternoon or even in the evening (late check-out). You will
-								find examples for this in Chapter 2, <link
+									>NeighbourComponentCorrection</link></para>
+							<para xml:id="en_9530" xml:lang="en">A second common scenario covers the opportunity for
+								customers departing late at night to use their room in the afternoon
+								or even in the evening (late check-out). You will find examples for
+								this in Chapter 2, <link
 									linkend="OtdsExperiencesNeighbourCorrectionComponent"
-									>NeighbourCorrectionComponent</link></para>
+									>NeighbourComponentCorrection</link></para>
 							<para xml:id="de_9002" xml:lang="de">Ab <emphasis role="bold">Version 2.0</emphasis> gibt es
 								auch die Möglichkeit, einer
 									<code>NeighbourComponentCorrection</code> eine Condition
@@ -21475,9 +21473,9 @@ usw.]]></programlisting>
 						calculation resulting from the data processing.</para>
 				</section>
 				<section xml:id="OtdsExperiencesNeighbourCorrectionComponent">
-					<title><phrase xml:id="de_9538" xml:lang="de"
-							>NeighbourCorrectionComponent</phrase><phrase xml:id="en_9538"
-							xml:lang="en">NeighbourCorrectionComponent</phrase></title>
+					<title><phrase xml:id="de_9538" xml:lang="de">NeighbourComponentCorrection</phrase><phrase
+								xml:id="en_9538" xml:lang="en"
+							>NeighbourComponentCorrection</phrase></title>
 					<para xml:id="de_9539" xml:lang="de">Bei der DayAllocation (der Zuordnung der Termine zu den
 							Reisekomponenten) darf in OTDS im Grunde bei Nachbarkomponenten keine
 							Lücke bestehen. Normalerweise schließt sich der CheckIn einer
@@ -21501,7 +21499,7 @@ usw.]]></programlisting>
 					<para xml:id="de_9540" xml:lang="de">Auf Veranstalterseite entsteht häufig Bedarf nach
 							flexiblen Strategien zur Zusteuerung von Hotels zu Flügen, die von der
 							Standard-Logik abweichen sollen. Eine solche Abweichung kann man mit dem
-								<code>NeighbourCorrectionComponent</code> (im Folgenden: NCC)
+								<code>NeighbourComponentCorrection</code> (im Folgenden: NCC)
 							abbilden. Reiseveranstalter möchten ihren Kunden beispielsweise mitunter
 							ermöglichen, bei sehr frühen Ankunftszeiten ihr Zimmer schon weit vor
 							der üblichen CheckIn-Zeit zu beziehen, um noch etwas zu schlafen. Dafür
@@ -21514,8 +21512,25 @@ usw.]]></programlisting>
 							eine "negative Lücke" also einen <code>NCC = -1</code> definiert. Damit
 							findet der CheckIn im Hotel einen Tag früher statt. Dazu folgendes
 							Beispiel:</para>
-					<para xml:id="en_9540" xml:lang="en">Among tour operators there often is a need for flexible strategies for the adding hotels to flights, which deviate from the standard logic. Such a deviation may be defined using the <code>NeighbourCorrectionComponent</code> (in the following: NCC).our operators, for example, sometimes want to enable their customers to move into their rooms well before the usual check-in time if their arrival times are very early, in order to get some sleep. standard logic. Such a deviation may be defined using the <code>NeighbourCorrectionComponent</code> (in the following: NCC). . For example, tour operators may want to very early arrival times, you can book your room well in advance. at the usual check-in time to get some sleep. For this the hotel has to be booked one night early. 
-						With the NCC a gap between neighboring components can be defined. In order to achieve the behavior described above, an overlap of one day must now be defined between the arrival date of the flight and the check-in date of the hotel. So one defines a <code>NCC</code>, which in interaction with the Accommodation defines a "negative gap", thus a <code>NCC = -1</code>. As a result the check-in in the hotel takes place one day earlier. The following example illustrates this:</para>
+					<para xml:id="en_9540" xml:lang="en">Among tour operators there often is a need for flexible
+							strategies for the adding hotels to flights, which deviate from the
+							standard logic. Such a deviation may be defined using the
+								<code>NeighbourComponentCorrection</code> (in the following:
+							NCC).our operators, for example, sometimes want to enable their
+							customers to move into their rooms well before the usual check-in time
+							if their arrival times are very early, in order to get some sleep.
+							standard logic. Such a deviation may be defined using the
+								<code>NeighbourComponentCorrection</code> (in the following: NCC). .
+							For example, tour operators may want to very early arrival times, you
+							can book your room well in advance. at the usual check-in time to get
+							some sleep. For this the hotel has to be booked one night early. With
+							the NCC a gap between neighboring components can be defined. In order to
+							achieve the behavior described above, an overlap of one day must now be
+							defined between the arrival date of the flight and the check-in date of
+							the hotel. So one defines a <code>NCC</code>, which in interaction with
+							the Accommodation defines a "negative gap", thus a <code>NCC =
+							-1</code>. As a result the check-in in the hotel takes place one day
+							earlier. The following example illustrates this:</para>
 					<programlisting><![CDATA[<OnewayFlight>
 	<OnewayFlight Key="FRAPMI20180331">
 		<Properties>
@@ -21589,7 +21604,7 @@ usw.]]></programlisting>
 							26.3. erfolgt. So wird dem Kunden der frühe Bezug seines Zimmers
 							ermöglicht.</para>
 					<para xml:id="en_9243" xml:lang="en">Here is the check-in date of the flight 27.3.2018, but the flight takes off so late (22:40h) that it lands on Fuerteventura the following day. Accordingly, the DateOffset marks this flight as an overnight flight. As in the above example, the tour operator defines with CheckOutDateOffset =-1 in <code>NCC</code> in relation to the Accommodation component a 1-day overlap of the CheckOut of the flight with the CheckIn of the hotel, so that the CheckIn of the hotel takes place on 26 March. This enables the customer to move into his room early.</para>
-					<para xml:id="de_9244" xml:lang="de">Die <code>NeighbourCorrectionComponent</code> kann auch
+					<para xml:id="de_9244" xml:lang="de">Die <code>NeighbourComponentCorrection</code> kann auch
 							für den Rückflug Anwendung finden: Bei spät abends oder in der Nacht
 							startenden Abflügen aus der Urlaubsdestination möchten manche
 							Veranstalter vielleicht als Mehrwert eine Reise anbieten, die es dem
@@ -21599,9 +21614,14 @@ usw.]]></programlisting>
 							definiert. Diesmal aber zwischen dem CheckIn des Rückfluges und dem
 							CheckOut der Unterkunft, also ein <code>CheckInDateOffset = -1</code>.
 							Das Beispiel dazu sieht wie folgt aus: </para>
-					<para xml:id="en_9244" xml:lang="en">The
-							<code>NeighbourCorrectionComponent</code> can also be applied to the
-						return flight: For late evening or night departures from the holiday destination, some operators may wish to offer an added value trip that allows the customer to spend part of the evening/night before the transfer in his room. As before, the <code>NCC</code> defines an overlap, i.e. a negative gap. In this case however it comes into effect between the CheckIn of the return flight and the CheckOut of the accommodation thus <code>CheckInDateOffset = -1</code></para>
+					<para xml:id="en_9244" xml:lang="en">The <code>NeighbourComponentCorrection</code> can also be
+							applied to the return flight: For late evening or night departures from
+							the holiday destination, some operators may wish to offer an added value
+							trip that allows the customer to spend part of the evening/night before
+							the transfer in his room. As before, the <code>NCC</code> defines an
+							overlap, i.e. a negative gap. In this case however it comes into effect
+							between the CheckIn of the return flight and the CheckOut of the
+							accommodation thus <code>CheckInDateOffset = -1</code></para>
 					<programlisting><![CDATA[<OnewayFlight>
 	<OnewayFlight Key="FUEFRA20180307">
 		<Properties>
@@ -21639,7 +21659,7 @@ usw.]]></programlisting>
 					<para xml:id="en_9245" xml:lang="en">In the example above, the return flight from Fuerteventura starts on 7.3.18 at 22:00 quite late in the evening; the arrival in Frankfurt takes place on the next calendar day early in the morning at 2:40 a.m.. Accordingly, the DateOffset marks this flight for the search as an overnight flight. So that the hotel room can be used by the traveller until 9 p.m., for example, the CheckOut in the hotel would have to take place one day later. To achieve this, an overlap ("negative gap") of one day is defined between the return flight and the CheckOut from the accommodation using <code>NCC</code>. The check-in for the return flight takes place on 07.03. The check-out in the accommodation is scheduled for 08.03..</para>
 					<para xml:id="de_9246" xml:lang="de">Genau umgekehrt verhält es sich bei früh morgens
 							startenden Abflügen aus der Urlaubsdestination (bspw. um 0:30 Uhr). Ohne
-							eine Steuerung mithilfe der <code>NeighbourCorrectionComponent</code>
+							eine Steuerung mithilfe der <code>NeighbourComponentCorrection</code>
 							würde der Kunde die Übernachtung in der Nacht vor dem Abflug voll
 							bezahlen müssen. Aufgrund von zeitaufwändigen Transfers und Wartezeiten
 							am Flughafen kann es ein sinnvolles/attraktives Angebot ergeben, keine
@@ -21650,17 +21670,18 @@ usw.]]></programlisting>
 								<code>NCC</code> eine Lücke zwischen dem CheckIn des Fluges und dem
 							CheckOut in der Unterkunft definieren. Ein Beispiel dafür finden Sie
 							hier: </para>
-					<para xml:id="en_9246" xml:lang="en">The opposite applies for flights departing
-						very early in the morning from the destination (e.g. at 0:30h). Without a
-						steering with the help of the <code>NeighbourCorrectionComponent</code> the
-						customer would have to pay the staynight for the night before departure. Due
-						to long transfer times and waiting hours at the airport it can make a
-						reasonable/attractive offer to leave out the last night in the hotel right
-						before the plane departs. The customer would then spend the time after the
-						hotel checkout without a room on the hotel grounds and save the costs for
-						this anyhow short night. To realize this, the <code>NCC</code> must advance
-						the CheckIn of the flight virtually one day, so that the stay in the hotel
-						may end earlier without producing gaps in the DayAllocation.</para>
+					<para xml:id="en_9246" xml:lang="en">The opposite applies for flights departing very early in
+							the morning from the destination (e.g. at 0:30h). Without a steering
+							with the help of the <code>NeighbourComponentCorrection</code> the
+							customer would have to pay the staynight for the night before departure.
+							Due to long transfer times and waiting hours at the airport it can make
+							a reasonable/attractive offer to leave out the last night in the hotel
+							right before the plane departs. The customer would then spend the time
+							after the hotel checkout without a room on the hotel grounds and save
+							the costs for this anyhow short night. To realize this, the
+								<code>NCC</code> must advance the CheckIn of the flight virtually
+							one day, so that the stay in the hotel may end earlier without producing
+							gaps in the DayAllocation.</para>
 					<programlisting><![CDATA[<OnewayFlight>
 	<OnewayFlight Key="FUEFRA20180307">
 		<Properties>


### PR DESCRIPTION
An einigen Stellen stand fälschlicherweise NeighbourCorrectionComponent. Habe das korrigiert in NeighbourComponentCorrection.