### PR TITLE
Texterweiterung Annotation UnitType

### DIFF
--- a/xsd/otds-schema-common.xsd
+++ b/xsd/otds-schema-common.xsd
@@ -1829,15 +1829,16 @@ etc.
 			<xs:element name="UnitInfo" type="ContentInfoType" minOccurs="0" internal:otdsversion="2.0"/>
 			<xs:element name="UnitType" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation xml:lang="de" xml:id="de_146">Art der Unit/Unterkunft: 
+					<xs:documentation xml:lang="de" xml:id="de_146">Art der Unit/Unterkunft zum Beispiel: 
 - Double
 - Apartment
 - Studio
 - Bungalow
 - Triple
 - Suite
-- Other. 
-Seit Version 1.1 können in diesem Element auch mehrere UnitTypes durch "Space" getrennt angegeben werden. Die Unit erfüllt damit alle der angegebenen Eigenschaften.</xs:documentation>
+- ... 
+Die komplette Liste der Types finden Sie im UnitTypeEnum.
+						Seit Version 1.1 können in diesem Element auch mehrere UnitTypes durch "Space" getrennt angegeben werden. Die Unit erfüllt damit alle der angegebenen Eigenschaften.</xs:documentation>
 					<xs:documentation xml:lang="en" xml:id="en_146">Type of unit / accommodation:
 Double
 Apartment


### PR DESCRIPTION
Textänderung soll verdeutlichen, dass die genannten UnitTypes nur ausgewählte Beispiele sind.