### PR TITLE
Update otds-schema-common.xsd

### DIFF
--- a/xsd/otds-schema-common.xsd
+++ b/xsd/otds-schema-common.xsd
@@ -3589,10 +3589,10 @@ Folgende Informationen können geliefert werden:
 			<xs:enumeration value="SemidetachedHouse"/>
 			<xs:enumeration value="Quad"/>
 			<xs:enumeration value="SingleWithChild"/>
-			<xs:enumeration value="MobileHome"/>
-			<xs:enumeration value="Tent"/>
+			<xs:enumeration value="MobileHome" internal:otdsversion="2.1.2"/>
+			<xs:enumeration value="Tent" internal:otdsversion="2.1.2"/>
 			<xs:enumeration value="JuniorSuite" internal:otdsversion="2.1.3"/>
-			<xs:enumeration value="HolidayFlat"/>
+			<xs:enumeration value="HolidayFlat" internal:otdsversion="2.1.2"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="UnitFacilitiesEnum">


### PR DESCRIPTION
Extended UnitType Enumeration with otdsversion attribute.
The attribute was forgotten, when the change in 2.1.2 was made.