### PR TITLE
Korrektur Doku Punkt statt Komma, Link

### DIFF
--- a/doku/spec/otds_spezifikation.docbook
+++ b/doku/spec/otds_spezifikation.docbook
@@ -36863,7 +36863,7 @@ Es geht um: <Seat Source="BookingClass" SourceEvaluationContext="IterationInstan
 								diese als "Nicht verfügbar". Nach diesem Prozess findet sich der
 								Verfügbarkeitsstatus des Angebots in der <code>Product</code>
 								Komponente. (siehe dazu auch "Auflistung aller Komponenten und
-								Unterkomponenten". <link linkend="GlossarSubComponent">Auflistung
+								Unterkomponenten". <link linkend="AppendixGlossar">Auflistung
 									der OTDS-Unterkomponenten</link>)</para>
 							<para xml:id="en_003130" xml:lang="en">Finally, the component availability
 								status is transferred to the parent components. A component is
@@ -36872,7 +36872,7 @@ Es geht um: <Seat Source="BookingClass" SourceEvaluationContext="IterationInstan
 								available for a component, it is categorised as "Not available".
 								After this process, the availability status of the offer can be
 								found in the <code>Product</code> component (see also "List of all
-								components and subcomponents" <link linkend="GlossarSubComponent"
+								components and subcomponents" <link linkend="AppendixGlossar"
 									>Directory of OTDS subcomponents</link>)</para>
 						</listitem>
 					</itemizedlist>
@@ -44072,7 +44072,7 @@ Es geht um: <Seat Source="BookingClass" SourceEvaluationContext="IterationInstan
 							<td rowspan="1" colspan="1">Accommodation</td>
 							<td rowspan="1" colspan="1">AccommodationOfficialCategory</td>
 							<td rowspan="1" colspan="1"><para xml:id="de_005541" xml:lang="de">Zahl
-									auch als Kommazahl in 0,5 Schritten</para><para xml:id="en_005541"
+									auch als Kommazahl in 0.5 Schritten</para><para xml:id="en_005541"
 									xml:lang="en">Number can be displayed as decimal with 0.5
 									ranges</para></td>
 							<td rowspan="1" colspan="1"><para xml:id="de_005542" xml:lang="de"
@@ -44084,7 +44084,7 @@ Es geht um: <Seat Source="BookingClass" SourceEvaluationContext="IterationInstan
 							<td rowspan="1" colspan="1">Accommodation</td>
 							<td rowspan="1" colspan="1">AccommodationOperatorCategory</td>
 							<td rowspan="1" colspan="1"><para xml:id="de_005543" xml:lang="de">Zahl
-									auch als Kommazahl in 0,5 Schritten</para><para xml:id="en_005543"
+									auch als Kommazahl in 0.5 Schritten</para><para xml:id="en_005543"
 									xml:lang="en">Number can be displayed as decimal with 0.5
 									ranges</para></td>
 							<td rowspan="1" colspan="1"><para xml:id="de_005544" xml:lang="de"


### PR DESCRIPTION
Link in Kapitel 3.4.2.2. auf Glossar korrigiert