### PR TITLE
AllInclusiveLight added

### DIFF
--- a/doku/spec/otds_spezifikation.docbook
+++ b/doku/spec/otds_spezifikation.docbook
@@ -45946,6 +45946,10 @@ Es geht um: <Seat Source="BookingClass" SourceEvaluationContext="IterationInstan
 										<para xml:id="en_004097" xml:lang="en">FullBoardPlus</para>
 									</listitem>
 									<listitem>
+										<para xml:id="de_010060" xml:lang="de">AllInclusiveLight (2.1.5)</para>
+										<para xml:id="en_010060" xml:lang="en">AllInclusiveLight (2.1.5)</para>
+									</listitem>
+									<listitem>
 										<para xml:id="de_004098" xml:lang="de">AllInclusive</para>
 										<para xml:id="en_004098" xml:lang="en">AllInclusive</para>
 									</listitem>

--- a/xsd/otds-schema-common.xsd
+++ b/xsd/otds-schema-common.xsd
@@ -1273,6 +1273,7 @@ As with other elements which are implemented as a list, in Version V2.0 the elem
 - HalfBoardPlus
 - FullBoard
 - FullBoardPlus
+- AllInclusiveLight
 - AllInclusive
 - AllInclusivePlus </xs:documentation>
 					<xs:documentation xml:lang="en" xml:id="en_00151">Type of catering:
@@ -1282,6 +1283,7 @@ As with other elements which are implemented as a list, in Version V2.0 the elem
 - HalfBoardPlus
 - FullBoard
 - FullBoardPlus
+- AllInclusiveLight
 - AllInclusive
 - AllInclusivePlus</xs:documentation>
 				</xs:annotation>
@@ -3579,6 +3581,7 @@ Folgende Informationen können geliefert werden:
 			<xs:enumeration value="FullBoardPlus"/>
 			<xs:enumeration value="AllInclusive"/>
 			<xs:enumeration value="AllInclusivePlus"/>
+			<xs:enumeration value="AllInclusiveLight" internal:otdsversion="2.1.5"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="BoardPropertiesEnum">


### PR DESCRIPTION
AI Light in docbook and otds-common.xsd.
ID's are correct.