### PR TITLE
Doku: Best Practice Availability Structure

### DIFF
--- a/doku/spec/otds_spezifikation.docbook
+++ b/doku/spec/otds_spezifikation.docbook
@@ -25442,7 +25442,7 @@ Es geht um: <Seat Source="BookingClass" SourceEvaluationContext="IterationInstan
 				</itemizedlist>
 			</section>
 			<section xml:id="OtdsBestPracticeStructureAvailabilities">
-				<title><phrase xml:id="de_006852" xml:lang="de">Empfohlene Struktur der Availabilties auf derselben Ebene</phrase>
+				<title><phrase xml:id="de_006852" xml:lang="de">Empfohlene Struktur der Availabilities auf derselben Ebene</phrase>
 					<phrase xml:id="en_006852" xml:lang="en">Recomended structure of Availabilities at the same level</phrase></title>
 				<para xml:id="de_009940" xml:lang="de">Die Definitionen der Verfügbarkeiten auf derselben Ebene (z.B. SellingUnit-Ebene) sollten geordnet und ohne Duplikate erfolgen.
 Der Technische Ausschuss empfiehlt folgende Struktur mit einer monatsweisen Lieferung je Availability-Element sowie eine sinnvolle Sortierung (bspw. in zeitlicher Order)</para>

--- a/doku/spec/otds_spezifikation.docbook
+++ b/doku/spec/otds_spezifikation.docbook
@@ -18043,6 +18043,8 @@ Es geht um: <Seat Source="BookingClass" SourceEvaluationContext="IterationInstan
 						day for all units as "available" and on the SellingUnit level the same day
 						is defined as "not available", then the definition of "not available" for
 						the relevant SellingUnit is prioritised.</para>
+					<para xml:id="de_001456" xml:lang="de">Empfehlungen zur geordneten Struktur von Availabilities finden sich unter den OTDS Praxisbeispielen <link linkend="OtdsBestPracticeStructureAvailabilities">"hier"</link>.</para>
+					<para xml:id="en_001456" xml:lang="en">Recommendations for an orderly structure of availabilities can be found in the OTDS best practices <link linkend="OtdsBestPracticeStructureAvailabilities">"here"</link>.</para>
 					<para xml:id="de_009253" xml:lang="de">Hinsichtlich der Availibility von Flügen
 						ist zu beachten, dass bei Übernachtflügen, die ja zwei Tage berühren, die
 						Availability zwei (oder bei noch längeren Flügen ggf. mehr) Tage abdecken

--- a/doku/spec/otds_spezifikation.docbook
+++ b/doku/spec/otds_spezifikation.docbook
@@ -25439,6 +25439,34 @@ Es geht um: <Seat Source="BookingClass" SourceEvaluationContext="IterationInstan
 					</listitem>
 				</itemizedlist>
 			</section>
+			<section xml:id="OtdsBestPracticeStructureAvailabilities">
+				<title><phrase xml:id="de_006852" xml:lang="de">Empfohlene Struktur der Availabilties auf derselben Ebene</phrase>
+					<phrase xml:id="en_006852" xml:lang="en">Recomended structure of Availabilities at the same level</phrase></title>
+				<para xml:id="de_009940" xml:lang="de">Die Definitionen der Verfügbarkeiten auf derselben Ebene (z.B. SellingUnit-Ebene) sollten geordnet und ohne Duplikate erfolgen.
+Der Technische Ausschuss empfiehlt folgende Struktur mit einer monatsweisen Lieferung je Availability-Element sowie eine sinnvolle Sortierung (bspw. in zeitlicher Order)</para>
+				<para xml:id="en_009940" xml:lang="en">The definitions of availabilities at the same level (e.g. SellingUnit level) should be ordered and without duplicates.
+The Technical Committee recommends the following structure with a monthly delivery per availability element and a sensible sorting (e.g. in chronological order).</para>
+			<programlisting><![CDATA[<Availabilities>
+   <Availability Key="2024_04" StartDate="2024-04-01" EndDate="2024-04-30">
+      <DefaultDayState>
+         <Closed/>
+      </DefaultDayState>
+      ...
+   </Availability>
+   <Availability Key="2024_05" StartDate="2024-05-01" EndDate="2024-05-31">
+      <DefaultDayState>
+         <Closed/>
+      </DefaultDayState>
+      ...
+   </Availability>
+</Availabilities>]]></programlisting>
+      <para xml:id="de_006851" xml:lang="de">Für mehr Informationen zu Availabilities sind die folgenden Kapitel hilfreich: <link
+							linkend="OtdsStrategyAvailabilityOverview">Übersicht Availiabilities</link> sowie <link
+							linkend="OtdsProcessAvailability">Verarbeitung der Availabilities</link>.</para>
+							<para xml:id="en_006851" xml:lang="en">For more information regarding Availabilities please refer to chapters<link
+							linkend="OtdsStrategyAvailabilityOverview">Overview Availiabilities</link> and  <link
+							linkend="OtdsProcessAvailability">Processing of availabilities</link>.</para>
+			</section>
 		</section>
 	</section>
 	<section xml:id="OtdsProcess">


### PR DESCRIPTION
Neu in Best Practices: Struktur von Availablilities
Brauchen wir auch einen Verweis aus Kapitel 1.3.13 Überblick Availablities und 3.4.2.2 Verarbeitung der Availablities auf das neu eingefügte Best Practice Kapitel mit der Availiablity Struktur?